### PR TITLE
Add MapLibre Native information and screenshots

### DIFF
--- a/guides/what_about_mobile.md
+++ b/guides/what_about_mobile.md
@@ -1,5 +1,25 @@
 
 
-MapLibre also provides [MapLibre Native](https://maplibre.org) an open-source SDK for Android and iOS.
+MapLibre also provides [MapLibre Native](https://maplibre.org) an open-source maps toolkit for Android, iOS and other platforms.
 
-If you have experience with these libraries (using VersaTiles), please help us to write this documentation.
+Since both MapLibre GL JS and MapLibre Native share the same [Style Specification](https://maplibre.org/maplibre-style-spec/), nothing special needs to be done to use Versatiles with MapLibre Native. For example, on iOS a Versatiles style URL can be passed to the initializer of [`MLNMapView`](https://maplibre.org/maplibre-native/ios/latest/documentation/maplibre/mlnmapview).
+
+```swift
+MLNMapView(frame: .zero, styleURL: URL(string: "https://tiles.versatiles.org/assets/styles/colorful.json")
+```
+
+While on Android you would call the `setStyle` method on a `MapView` to set the style:
+
+```kotlin
+mapView.getMapAsync { map ->
+    map.setStyle("https://tiles.versatiles.org/assets/styles/colorful.json")
+}
+```
+
+<p align="center">
+  <img height="600" alt="VersatilesMapLibre-iOS" src="https://github.com/versatiles-org/versatiles-documentation/assets/649392/3df3be25-d214-4449-b704-5430e556c26d">
+
+  <img height="600" alt="VersatilesMapLibre-Android" src="https://github.com/versatiles-org/versatiles-documentation/assets/649392/3098aec1-fd66-4e88-baf7-97cec3a00dc0">
+</p>
+
+Refer to the documentation of MapLibre Native for more information about using the toolkit.


### PR DESCRIPTION
Awesome project!

I tried using Versatiles with MapLibre Native. I came across some issues. For example, it looks like the Netherlands is under water on some zoom levels. On other zoom levels too many labels show, on some zoom levels too few. So I think the default styles need some optimization for mobile? I know this is not the right place to report this, just an observation.

This PR adds some more information about MapLibre Native. I'm available on the MapLibre Slack if you ever need more information. 🙂 

<img width="300" alt="water" src="https://github.com/versatiles-org/versatiles-documentation/assets/649392/f37126d7-cbe5-4fff-879a-5fa54dba9d9d"> <img width="300" alt="water2" src="https://github.com/versatiles-org/versatiles-documentation/assets/649392/955f2473-1c30-46cf-9b38-35aa228a235e">
